### PR TITLE
Added fallback value convertion

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,9 +162,11 @@ Edit the config.json with your favorite editor (i.e. nano): 'sudo nano /opt/can2
   "MqttUser": "",                   < This is the user that is required to register at the MQTT broker. Leave empty for none.
   "MqttPassword": "",               < This is the password that is required to register at the MQTT broker. Leave empty for none.
   "MqttAcceptSet": false,           < This is a setting, that defines if can2mqtt will send write-commands to the CAN bus. For safety reasons the default setting is set to false.  
-  
+
   "NoUnits": true,                  < This defines if sending MQTT messages will contain the unit defined in the translator config or not (i.e. "25°C" or just "25")  
-  "Language": "en"                  < This defines the language, that will be used. Currently available languages are "en" (English) and "de" (German).
+  "Language": "en",                 < This defines the language, that will be used. Currently available languages are "en" (English) and "de" (German).
+
+  "ConvertUnknown": false           < This defines if values of an unknown typed message (e.g., no entry in StiebelEltron.json) shall be converted with all possible formats and printed to console.
 }
 ```
 

--- a/can2mqtt_core/can2mqtt_core/ITranslator.cs
+++ b/can2mqtt_core/can2mqtt_core/ITranslator.cs
@@ -9,7 +9,7 @@ namespace can2mqtt
 {
     public interface ITranslator
     {
-        CanFrame Translate(CanFrame rawData, bool noUnit, string language);
+        CanFrame Translate(CanFrame rawData, bool noUnit, string language, bool convertUnknown);
         string TranslateBack(string mqttTopic, string value, string senderId, bool noUnit, string canOperation);
     }
 }

--- a/can2mqtt_core/can2mqtt_core/can2mqtt.cs
+++ b/can2mqtt_core/can2mqtt_core/can2mqtt.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Hosting;
+﻿using can2mqtt.Translator.StiebelEltron;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using MQTTnet;
 using MQTTnet.Client;
@@ -40,7 +41,7 @@ namespace can2mqtt
         private TcpClient ScdClient = null;
         private Translator.StiebelEltron.StiebelEltron Translator = null;
         private string Language = "EN";
-
+        private bool ConvertUnknown = false;
 
         public Can2Mqtt(ILogger<Can2Mqtt> logger)
         {
@@ -94,6 +95,7 @@ namespace can2mqtt
             CanSenderId = Convert.ToString(config["CanSenderId"]);
             CanInterfaceName = Convert.ToString(config["CanInterfaceName"]);
             Language = Convert.ToString(config["Language"]).ToUpper();
+            ConvertUnknown = bool.Parse(config["ConvertUnknown"].ToString());
 
             return true;
         }
@@ -485,8 +487,10 @@ namespace can2mqtt
                     switch (CanTranslator)
                     {
                         case "StiebelEltron":
-                            Translator = new Translator.StiebelEltron.StiebelEltron();
-                            canMsg = Translator.Translate(canMsg, NoUnit, Language);
+                            if (Translator == null) {
+                                Translator = new Translator.StiebelEltron.StiebelEltron();
+                            }
+                            canMsg = Translator.Translate(canMsg, NoUnit, Language, ConvertUnknown);
                             break;
                     }
                 }

--- a/can2mqtt_core/can2mqtt_core/config-sample.json
+++ b/can2mqtt_core/can2mqtt_core/config-sample.json
@@ -17,5 +17,6 @@
   "MqttAcceptSet": false,
 
   "NoUnits": false,
-  "Language": "en"
+  "Language": "en",
+  "ConvertUnknown": false
 }

--- a/can2mqtt_core/can2mqtt_core/translator/stiebel_eltron/StiebelEltron.cs
+++ b/can2mqtt_core/can2mqtt_core/translator/stiebel_eltron/StiebelEltron.cs
@@ -10,6 +10,7 @@ using System.Text;
 
 namespace can2mqtt.Translator.StiebelEltron
 {
+
     /// <summary>
     /// This Translator class translates the CAN Bus data to values
     /// Validated with:
@@ -17,7 +18,9 @@ namespace can2mqtt.Translator.StiebelEltron
     /// </summary>
     public class StiebelEltron : ITranslator
     {
-        public CanFrame Translate(CanFrame rawData, bool noUnit, string language)
+        private readonly FallbackValueConverter fallbackValueConverter = new();
+
+        public CanFrame Translate(CanFrame rawData, bool noUnit, string language, bool convertUnknown)
         {
             //Check if format is correct
             if (string.IsNullOrEmpty(rawData.PayloadFull) || rawData.PayloadFull.Length != 14)
@@ -48,8 +51,12 @@ namespace can2mqtt.Translator.StiebelEltron
             
 
             //Index not available
-            if (indexData == null)
+            if (indexData == null) {
+                if (convertUnknown) {
+                    Console.WriteLine($"Fallback convertion: {fallbackValueConverter.ConvertValue(payloadData)}");
+                }
                 return rawData;
+            }
 
             rawData.MqttTopicExtention = indexData.MqttTopic;
 

--- a/can2mqtt_core/can2mqtt_core/translator/stiebel_eltron/ValueConverter.cs
+++ b/can2mqtt_core/can2mqtt_core/translator/stiebel_eltron/ValueConverter.cs
@@ -550,4 +550,51 @@ namespace can2mqtt.Translator.StiebelEltron
             }
         }
     }
+
+    class FallbackValueConverter : IValueConverter
+    {
+        private struct Converter {
+            public string Name {get; init; }
+            public IValueConverter ValueConverter {get; init;}
+        }
+
+        private static readonly Converter[] Converters = [
+            new Converter { Name = "binary", ValueConverter = new ConvertBinary() },
+            new Converter { Name = "bool", ValueConverter = new ConvertBool() },
+            new Converter { Name = "byte", ValueConverter = new ConvertByte() },
+            new Converter { Name = "cent", ValueConverter = new ConvertCent() },
+            new Converter { Name = "datum", ValueConverter = new ConvertDate() },
+            new Converter { Name = "dec", ValueConverter = new ConvertDec() },
+            new Converter { Name = "default", ValueConverter = new ConvertDefault() },
+            new Converter { Name = "double", ValueConverter = new ConvertDouble() },
+            new Converter { Name = "err", ValueConverter = new ConvertErr() },
+            new Converter { Name = "littlebool", ValueConverter = new ConvertLittleBool() },
+            new Converter { Name = "littleendian", ValueConverter = new ConvertLittleEndian() },
+            new Converter { Name = "littleendiandec", ValueConverter = new ConvertLittleEndianDec() },
+            new Converter { Name = "mille", ValueConverter = new ConvertMille() },
+            new Converter { Name = "sprache", ValueConverter = new ConvertLanguage() },
+            new Converter { Name = "time", ValueConverter = new ConvertTime() },
+            new Converter { Name = "timedomain", ValueConverter = new ConvertTimeDomain() },
+            new Converter { Name = "timerange", ValueConverter = new ConvertTimeRange() },
+            new Converter { Name = "timerangelittleendian", ValueConverter = new ConvertTimeRangeLittleEndian() },
+            new Converter { Name = "triple", ValueConverter = new ConvertTriple() },
+            new Converter { Name = "Default", ValueConverter = new ConvertDefault() },
+        ];
+
+        public string ConvertValue(string hexData)
+        {
+            var sb = new StringBuilder();
+            foreach(var converter in Converters) {
+                try {
+                    sb.AppendLine($"{converter.Name}: {converter.ValueConverter.ConvertValue(hexData)}");
+                } catch(Exception) {}
+            }
+            return sb.ToString();
+        }
+
+        public string ConvertValueBack(string value)
+        {
+            throw new NotImplementedException();
+        }
+    }
 }


### PR DESCRIPTION
On my heat pump, the standard frames that the heat pump sends to the bus could not be translated.

To be able to complete the table, I have implemented a fallback value conversion functionality that helps to decode any value to compare it with the value on your WPM.