### PR TITLE
Do not publish values with unknown topic.

### DIFF
--- a/can2mqtt_core/can2mqtt_core/can2mqtt.cs
+++ b/can2mqtt_core/can2mqtt_core/can2mqtt.cs
@@ -511,6 +511,10 @@ namespace can2mqtt
                     }
                 }
 
+                if (string.IsNullOrEmpty(canMsg.MqttTopicExtention)) {
+                    return;
+                }
+
                 //Logoutput with or without translated MQTT message
                 if (string.IsNullOrEmpty(canMsg.MqttValue))
                     Console.WriteLine("Sending MQTT Message: {0} and Topic {1}", canMsg.PayloadFull.Trim(), MqttTopic);


### PR DESCRIPTION
On my heat pump, the standard frames that the heat pump sends to the bus could not be translated, resulting in messages posted to `MqttTopic` without any suffix. 