### PR TITLE
Fix loading elster table (StiebelEltron.json) multiple times

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,21 @@ A Linux or Windows service to forward CAN frames to MQTT messages
 This description describes the current release version. Possibly there are changes, if you build from code.
 
 # Latest Updates
+
+## V5.0
+
+Breaking changes:
+ - Running on .NET 8.0 instead of .NET 6.0
+
+New features:
+ - Added option `ConvertUnknown`, this defines if values of an unknown typed message (e.g., no entry in StiebelEltron.json) shall be converted with all possible formats and printed to console.
+ - Added fallback value converter for unknown indexes in StiebelEltron.json for easier debugging.
+
+Fixes:
+ - Do not publish unknown values to MQTT broker
+ - Load StiebelEltron.json only once during runtime
+
+## V4.4
 This software was just updated. The main and breaking changes are:
 - Running on .NET 6.0 instead of Dotnet Core 2.2
 - Using SOCKETCAND instead of CANLOGSERVER

--- a/can2mqtt_core/can2mqtt_core/translator/stiebel_eltron/StiebelEltron.cs
+++ b/can2mqtt_core/can2mqtt_core/translator/stiebel_eltron/StiebelEltron.cs
@@ -19,6 +19,8 @@ namespace can2mqtt.Translator.StiebelEltron
     public class StiebelEltron : ITranslator
     {
         private readonly FallbackValueConverter fallbackValueConverter = new();
+        // initialize elster index once
+        private static readonly ElsterIndex ElsterIndex = new();
 
         public CanFrame Translate(CanFrame rawData, bool noUnit, string language, bool convertUnknown)
         {
@@ -44,10 +46,9 @@ namespace can2mqtt.Translator.StiebelEltron
             var payloadData = rawData.Value;
 
             //Get IndexData
-            var elsterTable = new ElsterIndex();
-            var indexData = elsterTable.ElsterIndexTable.FirstOrDefault(x => x.Index == payloadIndex && x.Sender.ToString("X2") == rawData.PayloadSenderCanId );
+            var indexData = ElsterIndex.ElsterIndexTable.FirstOrDefault(x => x.Index == payloadIndex && x.Sender.ToString("X2") == rawData.PayloadSenderCanId );
             if (indexData == null)
-                indexData = elsterTable.ElsterIndexTable.FirstOrDefault(x => x.Index == payloadIndex);
+                indexData = ElsterIndex.ElsterIndexTable.FirstOrDefault(x => x.Index == payloadIndex);
             
 
             //Index not available

--- a/can2mqtt_core/can2mqtt_core/translator/stiebel_eltron/StiebelEltron.cs
+++ b/can2mqtt_core/can2mqtt_core/translator/stiebel_eltron/StiebelEltron.cs
@@ -116,8 +116,7 @@ namespace can2mqtt.Translator.StiebelEltron
             }
 
             // Get the Elster Index by the topic
-            var elsterTable = new ElsterIndex();
-            var elsterItem = elsterTable.ElsterIndexTable.FirstOrDefault(x => x.MqttTopic == topic);
+            var elsterItem = ElsterIndex.ElsterIndexTable.FirstOrDefault(x => x.MqttTopic == topic);
 
             //Index not available
             if (elsterItem == null)


### PR DESCRIPTION
StiebelEltron.json was loaded for every received message on the can bus. It is now a static variable and therefore only loaded once during runtime.

Next I have updated the README :) 

I skipped the dotnet installation instructions since this is something you can easily google or ask chatgpt so I dont think it is worth mentioning in the README. Maybe you consider to remove it.