### PR TITLE
Code improvements

### DIFF
--- a/can2mqtt_core/can2mqtt_core/LogFormatter.cs
+++ b/can2mqtt_core/can2mqtt_core/LogFormatter.cs
@@ -1,0 +1,33 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Logging.Console;
+using Microsoft.Extensions.Options;
+
+public sealed class Can2MqttLogFormatter : ConsoleFormatter, IDisposable
+{
+    private readonly IDisposable _optionsReloadToken;
+    private ConsoleFormatterOptions _formatterOptions;
+
+    public Can2MqttLogFormatter(
+        IOptionsMonitor<ConsoleFormatterOptions> options)
+        : base(nameof(Can2MqttLogFormatter))
+    {
+        _optionsReloadToken = options.OnChange(ReloadLoggerOptions);
+        _formatterOptions = options.CurrentValue;
+    }
+
+    private void ReloadLoggerOptions(ConsoleFormatterOptions options) => _formatterOptions = options;
+
+    public void Dispose() => _optionsReloadToken?.Dispose();
+
+    public override void Write<TState>(in LogEntry<TState> logEntry, IExternalScopeProvider scopeProvider, TextWriter textWriter)
+    {
+        var message = logEntry.Formatter(logEntry.State, logEntry.Exception);
+        if (string.IsNullOrWhiteSpace(message))
+        {
+            return;
+        }
+
+        var now = _formatterOptions.UseUtcTimestamp ? DateTime.UtcNow : DateTime.Now;
+        textWriter.WriteLine($"{now:yyyy-MM-dd HH:mm:ss.fff} {logEntry.Category} [{logEntry.LogLevel}]: {message}");
+    }
+}

--- a/can2mqtt_core/can2mqtt_core/Program.cs
+++ b/can2mqtt_core/can2mqtt_core/Program.cs
@@ -1,6 +1,4 @@
 ﻿using can2mqtt;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 
 IHost host = Host.CreateDefaultBuilder(args)
     .ConfigureServices(services =>

--- a/can2mqtt_core/can2mqtt_core/Program.cs
+++ b/can2mqtt_core/can2mqtt_core/Program.cs
@@ -1,8 +1,16 @@
 ﻿using can2mqtt;
+using Microsoft.Extensions.Logging.Console;
 
 IHost host = Host.CreateDefaultBuilder(args)
     .ConfigureServices(services =>
     {
+        services.AddLogging(logging =>
+        {
+            logging.ClearProviders();
+            logging.AddConsole();
+            logging.AddConsoleFormatter<Can2MqttLogFormatter, ConsoleFormatterOptions>();
+        });
+
         services.AddHostedService<Can2Mqtt>();
     })
     .Build();

--- a/can2mqtt_core/can2mqtt_core/appsettings.Development.json
+++ b/can2mqtt_core/can2mqtt_core/appsettings.Development.json
@@ -5,11 +5,9 @@
       "Microsoft.Hosting.Lifetime": "Information"
     },
     "Console": {
-      "FormatterName": "simple",
+      "FormatterName": "Can2MqttLogFormatter",
       "FormatterOptions": {
-        "SingleLine": false,
-        "IncludeScopes": true,
-        "TimestampFormat": "yyyy-MM-dd HH:mm:ss.ffff ",
+        "TimestampFormat": "yyyy-MM-dd HH:mm:ss.fff ",
         "UseUtcTimestamp": true
       }
     }

--- a/can2mqtt_core/can2mqtt_core/appsettings.Development.json
+++ b/can2mqtt_core/can2mqtt_core/appsettings.Development.json
@@ -3,6 +3,15 @@
     "LogLevel": {
       "Default": "Information",
       "Microsoft.Hosting.Lifetime": "Information"
+    },
+    "Console": {
+      "FormatterName": "simple",
+      "FormatterOptions": {
+        "SingleLine": false,
+        "IncludeScopes": true,
+        "TimestampFormat": "yyyy-MM-dd HH:mm:ss.ffff ",
+        "UseUtcTimestamp": true
+      }
     }
   }
 }

--- a/can2mqtt_core/can2mqtt_core/appsettings.json
+++ b/can2mqtt_core/can2mqtt_core/appsettings.json
@@ -5,11 +5,9 @@
       "Microsoft.Hosting.Lifetime": "Information"
     },
     "Console": {
-      "FormatterName": "simple",
+      "FormatterName": "Can2MqttLogFormatter",
       "FormatterOptions": {
-        "SingleLine": false,
-        "IncludeScopes": true,
-        "TimestampFormat": "yyyy-MM-dd HH:mm:ss.ffff ",
+        "TimestampFormat": "yyyy-MM-dd HH:mm:ss.fff ",
         "UseUtcTimestamp": true
       }
     }

--- a/can2mqtt_core/can2mqtt_core/appsettings.json
+++ b/can2mqtt_core/can2mqtt_core/appsettings.json
@@ -3,6 +3,15 @@
     "LogLevel": {
       "Default": "Information",
       "Microsoft.Hosting.Lifetime": "Information"
+    },
+    "Console": {
+      "FormatterName": "simple",
+      "FormatterOptions": {
+        "SingleLine": false,
+        "IncludeScopes": true,
+        "TimestampFormat": "yyyy-MM-dd HH:mm:ss.ffff ",
+        "UseUtcTimestamp": true
+      }
     }
   }
 }

--- a/can2mqtt_core/can2mqtt_core/translator/stiebel_eltron/StiebelEltron.cs
+++ b/can2mqtt_core/can2mqtt_core/translator/stiebel_eltron/StiebelEltron.cs
@@ -61,7 +61,7 @@ namespace can2mqtt.Translator.StiebelEltron
             //Index not available
             if (indexData == null) {
                 if (convertUnknown) {
-                    Logger.LogInformation($"Fallback convertion: {fallbackValueConverter.ConvertValue(payloadData)}");
+                    Logger.LogInformation($"Fallback convertion:{Environment.NewLine}{fallbackValueConverter.ConvertValue(payloadData)}");
                 }
                 return rawData;
             }


### PR DESCRIPTION
- Solved code duplication
- Formatted code
- Improved error handling when config.json cannot be parsed (e.g. option is missing)
- Removed `Sending CAN Verify Frame` completely - reason: this caused every sent frame to be ACKed and requested again. When I read a value from my heat pump it was always requested twice and also twice sent to the MQTT broken because of the verify frame. If it is really necessary I will make it configurable.
- Use Microsoft Logging infrastructure instead of Console.WriteLine for more control about logged messages, e.g. debug messages can be enabled only for developers.

Log messages now look like this:

```
2025-01-15 20:06:05.962 can2mqtt [Information]: CONNECTED TO SOCKETCAND 127.0.0.1 ON PORT 29536
2025-01-15 20:06:05.963 can2mqtt [Information]: Handshake successful. Opening CAN interface...
2025-01-15 20:06:05.964 can2mqtt [Information]: Opening connection to slcan0 successful. Changing socketcand mode to raw...
2025-01-15 20:06:05.984 can2mqtt [Information]: Change to rawmode successful
2025-01-15 20:06:09.546 can2mqtt [Information]: Received CAN Frame: < frame 100 1736971569.542967 31000C00000000 >
2025-01-15 20:06:09.554 can2mqtt [Information]: Received CAN Frame: < frame 180 1736971569.553486 22000CFFF70000 >
2025-01-15 20:06:09.574 can2mqtt [Information]: Sending MQTT Message: -0.9 and Topic homeassistant/sensor/stiebel_eltron_outside_temperature
2025-01-15 20:06:10.288 can2mqtt [Information]: Received CAN Frame: < frame 100 1736971570.286793 41010E00000000 >
2025-01-15 20:06:10.296 can2mqtt [Information]: Received CAN Frame: < frame 201 1736971570.295539 22000E018A0000 >
2025-01-15 20:06:10.296 can2mqtt [Information]: Sending MQTT Message: 39.4 and Topic homeassistant/sensor/stiebel_eltron_hot_water_current_temperature
2025-01-15 20:06:11.033 can2mqtt [Information]: Received CAN Frame: < frame 100 1736971571.030710 C101FA4EB40000 >
2025-01-15 20:06:11.034 can2mqtt [Information]: Received CAN Frame: < frame 601 1736971571.032654 2200FA4EB40116 >
2025-01-15 20:06:11.044 StiebelEltronTranslator [Information]: Fallback convertion:
binary: 0000000100010110
bool: ???
byte: 255
cent: 2.78
datum: 01.22.
dec: 27.8
default: 278
double: 278
err: littlebool: ???
littleendian: 5633
littleendiandec: 563.3
mille: 0.278
sprache: Unknown (0116)
time: 21:30
timedomain: 00:15 - 05:30
timerange: 00:15 - 05:30
timerangelittleendian: 05:30 - 00:15
triple: 278
Default: 278
```