### PR TITLE
Throttle auto polling to avoid connection loss

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Breaking changes:
 New features:
  - Added option `ConvertUnknown`, this defines if values of an unknown typed message (e.g., no entry in StiebelEltron.json) shall be converted with all possible formats and printed to console.
  - Added fallback value converter for unknown indexes in StiebelEltron.json for easier debugging.
- - Added automatic polling feature. It can be enabled using config option `AutoPolling`. The polling interval **in seconds** can be defined with `AutoPollingInterval`. If a value shall not be polled, add `"IgnorePolling": true` to `StiebelEltron.json`.
+ - Added automatic polling feature. It can be enabled using config option `AutoPolling`. The polling interval **in seconds** can be defined with `AutoPollingInterval`. To avoid connection loss to socketcand `AutoPollingThrottle` needs to be specified **in milliseconds**. This delay will be introduced between each sent read. If a value shall not be polled, add `"IgnorePolling": true` to `StiebelEltron.json`.
 
 Fixes:
  - Do not publish unknown values to MQTT broker
@@ -184,6 +184,9 @@ Edit the config.json with your favorite editor (i.e. nano): 'sudo nano /opt/can2
   "Language": "en",                 < This defines the language, that will be used. Currently available languages are "en" (English) and "de" (German).
 
   "ConvertUnknown": false           < New in Release 5.0; This defines if values of an unknown typed message (e.g., no entry in StiebelEltron.json) shall be converted with all possible formats and printed to console.
+  "AutoPolling": false,             < New in Release 5.0: This defines if values shall be polled automatically.
+  "AutoPollingInterval": 30         < New in Release 5.0: If AutoPolling is enabled, this value defines the interval in which values are polled in seconds. e.g. 30s.
+  "AutoPollingThrottle": 150        < New in Release 5.0: Throttle time between each sent read request in milliseconds. Adapt in case connection to socketcand is lost when auto polling is enabled.
 }
 ```
 
@@ -208,6 +211,12 @@ If you need to request a send from the CAN bus, you can add a /read at the end o
 An example MQTT message to can2mqtt to request the value of the desired room temperature of the primary heat cycle:
 Topic: heating/room/hc1/temperature/day/read
 
+# Stiebel Eltron Elster Table
+
+The following section describes the format of `can2mqtt_core/can2mqtt_core/translator/stiebel_eltron/StiebelEltron.json`.
+
+## Ignore from auto polling
+If a value shall not be polled, add `"IgnorePolling": true` entry.
 
 # Troubleshooting
 ## Issue: The connection is reconnecting over and over again multiple times within seconds until the application crashes

--- a/can2mqtt_core/can2mqtt_core/can2mqtt.cs
+++ b/can2mqtt_core/can2mqtt_core/can2mqtt.cs
@@ -38,6 +38,7 @@ namespace can2mqtt
 
         private bool AutoPolling = false;
         private int AutoPollingInterval = 120; // in seconds
+        private int AutoPollingThrottle = 150; // in milliseconds
         private Task AutoPollingTask = null;
 
         private readonly ILoggerFactory LoggerFactory;
@@ -99,6 +100,7 @@ namespace can2mqtt
                 ConvertUnknown = bool.Parse(config["ConvertUnknown"].ToString());
                 AutoPolling = bool.Parse(config["AutoPolling"].ToString());
                 AutoPollingInterval = Convert.ToInt32(config["AutoPollingInterval"].ToString());
+                AutoPollingThrottle = Convert.ToInt32(config["AutoPollingThrottle"].ToString());
 
                 //choose the translator to use and translate the message if translator exists
                 switch (CanTranslator)
@@ -559,6 +561,8 @@ namespace can2mqtt
                     foreach (var mqttTopic in Translator.MqttTopicsToPoll)
                     {
                         await ReadCan(mqttTopic + "/read", CanServer, CanServerPort);
+                        // delay next read to avoid overloading socketcand
+                        await Task.Delay(AutoPollingThrottle, stoppingToken);
                     }
                 }
             });

--- a/can2mqtt_core/can2mqtt_core/config-sample.json
+++ b/can2mqtt_core/can2mqtt_core/config-sample.json
@@ -21,5 +21,6 @@
   "ConvertUnknown": false,
 
   "AutoPolling": false,
-  "AutoPollingInterval": 120
+  "AutoPollingInterval": 120,
+  "AutoPollingThrottle": 150
 }


### PR DESCRIPTION
On my machine socketcand closed connection in case too many read requests were sent within a very short period of time.

That's why I have added this simple throttling. 

In my case 100-150ms delay was enough, but I made it configurable so it can be increased if needed.